### PR TITLE
fix: add imageUrl field to ItemEntity and update constructor, getters…

### DIFF
--- a/backend/wildcats-finder/src/main/java/com/wildcatsfinder/wildcats_finder/entity/ItemEntity.java
+++ b/backend/wildcats-finder/src/main/java/com/wildcatsfinder/wildcats_finder/entity/ItemEntity.java
@@ -25,6 +25,9 @@ public class ItemEntity {
     @Column(name = "location")
     private String location;
 
+    @Column(name = "image_url")
+    private String imageUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private ItemStatus status;
@@ -56,12 +59,13 @@ public class ItemEntity {
     }
 
     public ItemEntity(String itemTitle, String itemDesc, LocalDateTime dateReport,
-            String location, ItemStatus status, UserEntity user,
+            String location, String imageUrl, ItemStatus status, UserEntity user,
             CategoryEntity category, DepartmentEntity department) {
         this.itemTitle = itemTitle;
         this.itemDesc = itemDesc;
         this.dateReport = dateReport;
         this.location = location;
+        this.imageUrl = imageUrl;
         this.status = status;
         this.user = user;
         this.category = category;
@@ -107,6 +111,14 @@ public class ItemEntity {
 
     public void setLocation(String location) {
         this.location = location;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 
     public ItemStatus getStatus() {


### PR DESCRIPTION

This pull request adds support for storing an image URL with each item in the `ItemEntity` class. The main changes include updating the entity to include an `imageUrl` field, modifying the constructor to accept this new field, and adding getter and setter methods for it.

**Item image support:**

* Added a new `imageUrl` field to the `ItemEntity` class and mapped it to the database with the `@Column` annotation.
* Updated the `ItemEntity` constructor to include the `imageUrl` parameter and set its value.
* Added `getImageUrl` and `setImageUrl` methods to allow accessing and modifying the image URL of an item.